### PR TITLE
Allow full paths to be specified on the command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ This will tell the script to search for all images with a resolution of 1920x108
 You can also specify a full path.
 
 ```shell
-interfacelift-downloader ~/Downloads/1920x1080
+interfacelift-downloader 1920x1080 ~/downloads/1920x1080
 ```
 
 ```shell
-interfacelift-downloader /Users/steven/Downloads/1920x1080
+interfacelift-downloader 1920x1080 /Users/steven/downloads/1920x1080
 ```
 
 ## Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Navigate to the path that you want to save the files in and execute the `interfa
 ```shell
 interfacelift-downloader 1920x1080
 ```
-
 This will tell the script to search for all images with a resolution of 1920x1080 pixels and save them to your current working directory. It will not download or overwrite any existing files.
 
 ### To save files to a specific folder
@@ -48,6 +47,16 @@ interfacelift-downloader 1920x1080 downloads/1920x1080
 ```
 
 This will tell the script to search for all images with a resolution of 1920x1080 pixels and save them to the downloads/1920x1080 directory. It will not download or overwrite any existing files.
+
+You can also specify a full path.
+
+```shell
+interfacelift-downloader ~/Downloads/1920x1080
+```
+
+```shell
+interfacelift-downloader /Users/steven/Downloads/1920x1080
+```
 
 ## Reporting Bugs
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You now have access to the `interfacelift-downloader` command.
 The `interfacelift-downloader` command accepts two arguments:
 
 * The **resolution** option needs to be the image resolution that you want to search for (e.g. 1920x1080).
-* The **path** is the path to save the downloaded files to. If specified this must be a path to a folder based on your current working directory (e.g. downloads, or ../wallpaper/1080). If this option is omitted then files will be saved to your current working directory.
+* The **path** is the path to save the downloaded files to. If specified this must be a path to a folder based on your current working directory (e.g. downloads, or ../wallpaper/1080) or the full path. (e.g. ~/downloads, or /Users/steven/downloads) If this option is omitted then files will be saved to your current working directory.
 
 ### To save files to your current folder
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,7 +35,12 @@ module.exports = {
     }
 
     if (args.length >= 4) {
-      downloadPath = path.join(downloadPath, args[3]);
+      if (args[3].charAt(0) == "/" || args[3].charAt(0) == "~") {
+        downloadPath = args[3];
+      } else {
+        downloadPath = path.join(downloadPath, args[3]);
+      }
+
       if (!fs.existsSync(downloadPath)) {
         console.log('The path "' + args[3] + '" does not exist.');
         process.exit(1);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,7 +35,7 @@ module.exports = {
     }
 
     if (args.length >= 4) {
-      if (args[3].charAt(0) == "/" || args[3].charAt(0) == "~") {
+      if (args[3].charAt(0) === '/' || args[3].charAt(0) === '~') {
         downloadPath = args[3];
       } else {
         downloadPath = path.join(downloadPath, args[3]);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,12 +35,8 @@ module.exports = {
     }
 
     if (args.length >= 4) {
-      if (args[3].charAt(0) === '/' || args[3].charAt(0) === '~') {
-        downloadPath = args[3];
-      } else {
-        downloadPath = path.join(downloadPath, args[3]);
-      }
-
+      downloadPath = path.resolve(downloadPath, args[3]);
+      
       if (!fs.existsSync(downloadPath)) {
         console.log('The path "' + args[3] + '" does not exist.');
         process.exit(1);


### PR DESCRIPTION
Example paths to be allowed on the command line:

```shell
interfacelift-downloader 1920x1080 /Users/steven/downloads/1920x1080
```
```shell
interfacelift-downloader 1920x1080 ~/downloads/1920x1080
```