### PR TITLE
Add download limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ You now have access to the `interfacelift-downloader` command.
 
 ## Usage
 
-`interfacelift-downloader [resolution] [path]`
+`interfacelift-downloader [resolution] [path] [download limit]`
 
 The `interfacelift-downloader` command accepts two arguments:
 
 * The **resolution** option needs to be the image resolution that you want to search for (e.g. 1920x1080).
 * The **path** is the path to save the downloaded files to. If specified this must be a path to a folder based on your current working directory (e.g. downloads, or ../wallpaper/1080) or the full path. (e.g. ~/downloads, or /Users/steven/downloads) If this option is omitted then files will be saved to your current working directory.
+* The **download limit** is the number of files to download. For example, if this option is set to 5, the 5 most recent images will be downloaded. If this option is omitted or set to 0, there is no limit and all the images are downloaded.
 
 ### To save files to your current folder
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -102,9 +102,11 @@ module.exports = {
 
   help: function() {
     console.log([
-      'Usage: node interfacelift-downloader [resolution] [path]',
+      'Usage: node interfacelift-downloader [resolution] [path] [download limit]',
       'Resolution is the dimensions of the images you want to search for.',
-      'For example: interfacelift-downloader 1920x1080'
+      'For example: interfacelift-downloader 1920x1080',
+      'Download limit is an optional argument that controls how many images are downloaded.',
+      'For example: interfacelift-downloader 1920x1080 . 5'
     ].join('\n'));
   }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,8 +19,9 @@ module.exports = {
   process: function(args) {
     var resolution = '1920x1080';
     var downloadPath = process.cwd();
+    var downloadLimit = 0;
 
-    if (args.length > 4 || (args.length === 3 && args[2] === '--help')) {
+    if (args.length > 5 || (args.length === 3 && args[2] === '--help')) {
       module.exports.help();
       process.exit(0);
     }
@@ -42,12 +43,19 @@ module.exports = {
       }
     }
 
-    module.exports.run(resolution, downloadPath);
+    if (args.length >= 5) {
+        downloadLimit = parseInt(args[4], 10);
+        if (isNaN(downloadLimit)) {
+            console.log('"' + args[4] + '" is not a valid download limit.');
+            process.exit(1);
+        }
+    }
+    module.exports.run(resolution, downloadPath, downloadLimit);
   },
 
-  run: function(resolution, downloadPath) {
+  run: function(resolution, downloadPath, downloadLimit) {
     var startTime = new Date();
-    var ps = new PageScraper(resolution);
+    var ps = new PageScraper(resolution, downloadLimit);
     var existingFiles = 0;
 
     // run the page scraper

--- a/lib/pagescraper.js
+++ b/lib/pagescraper.js
@@ -17,7 +17,7 @@ var DLREGEX = /\/wallpaper\/[\w]+\/\d+_\w+\.jpg/ig;
 var USERAGENT = 'Mozilla/4.8 [en] (Windows NT 6.0; U)';
 var HOST = 'interfacelift.com';
 
-module.exports = function(resolution) {
+module.exports = function(resolution, downloadLimit) {
   var resPath = resPaths[resolution];
   var downloadLinks = [];
   var me = this;
@@ -58,7 +58,12 @@ module.exports = function(resolution) {
 
         // if there is a next page run the next callback, or end
         if (pageData.indexOf(nextPage) > -1) {
-          me.emit('next', pageNumber, nextPage);
+          // check that download limit has not been reached
+          if (downloadLimit === 0 || downloadLinks.length < downloadLimit) {
+            me.emit('next', pageNumber, nextPage);
+          } else {
+            me.emit('end', downloadLinks.slice(0, downloadLimit));
+          }
         } else {
           me.emit('end', downloadLinks);
         }


### PR DESCRIPTION
This option is very useful for someone who just wants to get the most recent X images. It makes the process much faster as not all the pages need to be scanned and only the first X images are downloaded.
