### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node
+
+WORKDIR /home/downloader
+
+RUN git clone https://github.com/stevenbenner/interfacelift-downloader.git && \
+    npm install -g interfacelift-downloader
+
+VOLUME ["/downloads"]
+
+WORKDIR /downloads
+
+ARG uid=0
+ARG gid=0
+
+USER ${uid}:${gid}
+
+ENTRYPOINT ["interfacelift-downloader", "1920x1080", "/downloads"]
+
+CMD ["1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM node
 
 WORKDIR /home/downloader
 
-RUN git clone https://github.com/stevenbenner/interfacelift-downloader.git && \
-    npm install -g interfacelift-downloader
+ADD . /home/downloader
+
+RUN npm install -g interfacelift-downloader
 
 VOLUME ["/downloads"]
 


### PR DESCRIPTION
This PR adds a Dockerfile that allows you to run the downloader without having to install `nodejs` or add a global package. It defines a docker volume at `/downloads` that you can mount to where you want your wallpapers to be downloaded.

To build the docker image, clone the repo and then execute the following command inside the cloned repo:

    docker build -t interfacelift/downloader --build-arg uid=1000 --build-arg gid=1000 .

The `uid` and `gid` arguments are optional, but I recommend using them so your wallpapers are created using your own user and group instead of `root`.

After building the image, you can run the downloader using the following command:

    docker run --rm -v $(pwd):/downloads interfacelift/downloader

This will download 1 image in the current directory. If you want to download more than one image, you can pass the number to the run command. This will download 10 images:

    docker run --rm -v $(pwd):/downloads interfacelift/downloader 10

I couldn't figure out a way to change the resolution and still keep the nice exec form for `ENTRYPOINT`, since it doesn't do argument substitution. If I think of a way around that, I will add it and update. Right now, the default resolution is `1920x1080`, and I'm afraid you have to modify and build the Dockerfile if you need a different resolution.

I hope this is helpful for others too.